### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/857/939/27/85793927.geojson
+++ b/data/857/939/27/85793927.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1082622
     },
     "wof:country":"MQ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8979dd073472b7c158bb7be9971ca6d9",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566611829,
+    "wof:lastmodified":1582379099,
     "wof:name":"Case Navire",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/33/85793933.geojson
+++ b/data/857/939/33/85793933.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1165140
     },
     "wof:country":"MQ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8dca89300d43865df1bf8cd7169f300e",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566611829,
+    "wof:lastmodified":1582379099,
     "wof:name":"Coridon",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/37/85793937.geojson
+++ b/data/857/939/37/85793937.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":228583
     },
     "wof:country":"MQ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f9fd08dcaaf77430f038e46ad1cb27d",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566611829,
+    "wof:lastmodified":1582379099,
     "wof:name":"Faubourg Sch\u0153lcher",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/41/85793941.geojson
+++ b/data/857/939/41/85793941.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":279780
     },
     "wof:country":"MQ",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"862cf4fd080679649e577767fed2c4f5",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566611829,
+    "wof:lastmodified":1582379100,
     "wof:name":"Ste.-Th\u00e9r\u00e8se",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.