### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/582/507/7/1125825077.geojson
+++ b/data/112/582/507/7/1125825077.geojson
@@ -55,6 +55,9 @@
     "name:ben_x_preferred":[
         "\u09ab\u09cb\u09b0\u09cd\u099f-\u09a1\u09bf-\u09ab\u09cd\u09b0\u09be\u09a8\u09cd\u09b8"
     ],
+    "name:ben_x_variant":[
+        "\u09ab\u09b0-\u09a6\u09cd\u09af-\u09ab\u09cd\u09b0\u0981\u09b8"
+    ],
     "name:bos_x_preferred":[
         "Fort-de-France"
     ],
@@ -72,6 +75,12 @@
     ],
     "name:ces_x_preferred":[
         "Fort-de-France"
+    ],
+    "name:che_x_preferred":[
+        "\u0424\u043e\u0433\u04c0-\u0434\u0435-\u0424\u0433\u04c0\u0430\u043d\u0441"
+    ],
+    "name:chv_x_preferred":[
+        "\u0424\u043e\u0440-\u0434\u0435-\u0424\u0440\u0430\u043d\u0441"
     ],
     "name:cor_x_preferred":[
         "Fort-de-France"
@@ -132,6 +141,12 @@
     ],
     "name:frp_x_preferred":[
         "F\u00f4rt-de-France"
+    ],
+    "name:frr_x_preferred":[
+        "Fort-de-France"
+    ],
+    "name:fry_x_preferred":[
+        "Fort-de-France"
     ],
     "name:fur_x_preferred":[
         "Fort-de-France"
@@ -231,6 +246,9 @@
     ],
     "name:lit_x_preferred":[
         "For de Fransas"
+    ],
+    "name:lld_x_preferred":[
+        "Fort-de-France"
     ],
     "name:lmo_x_preferred":[
         "Fort-de-France"
@@ -421,6 +439,9 @@
     "name:wol_x_preferred":[
         "Fort-de-France"
     ],
+    "name:wuu_x_preferred":[
+        "\u6cd5\u5170\u897f\u5821"
+    ],
     "name:yor_x_preferred":[
         "Fort-de-France"
     ],
@@ -581,7 +602,7 @@
         }
     ],
     "wof:id":1125825077,
-    "wof:lastmodified":1607390882,
+    "wof:lastmodified":1690939777,
     "wof:name":"Fort-de-France",
     "wof:parent_id":85671191,
     "wof:placetype":"locality",

--- a/data/112/593/909/3/1125939093.geojson
+++ b/data/112/593/909/3/1125939093.geojson
@@ -46,6 +46,9 @@
     "name:ces_x_preferred":[
         "Saint-Esprit"
     ],
+    "name:che_x_preferred":[
+        "\u0421\u0435\u043d\u0442-\u0415\u0441\u043f\u0433\u04c0\u0438"
+    ],
     "name:cos_x_preferred":[
         "Saint-Esprit"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:deu_x_preferred":[
         "Saint-Esprit"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a3\u03b1\u03b9\u03bd\u03c4-\u0395\u03c3\u03c0\u03c1\u03af"
     ],
     "name:eng_x_preferred":[
         "Saint-Esprit"
@@ -149,6 +155,9 @@
         "Saint-Esprit"
     ],
     "name:lit_x_preferred":[
+        "Saint-Esprit"
+    ],
+    "name:lld_x_preferred":[
         "Saint-Esprit"
     ],
     "name:ltz_x_preferred":[
@@ -268,6 +277,9 @@
     "name:wol_x_preferred":[
         "Saint-Esprit"
     ],
+    "name:zho_x_preferred":[
+        "\u5723\u57c3\u65af\u666e\u91cc"
+    ],
     "name:zul_x_preferred":[
         "Saint-Esprit"
     ],
@@ -310,7 +322,7 @@
         }
     ],
     "wof:id":1125939093,
-    "wof:lastmodified":1566611881,
+    "wof:lastmodified":1690939776,
     "wof:name":"Saint-Esprit",
     "wof:parent_id":85671191,
     "wof:placetype":"locality",

--- a/data/112/593/910/7/1125939107.geojson
+++ b/data/112/593/910/7/1125939107.geojson
@@ -25,6 +25,9 @@
     "name:afr_x_preferred":[
         "Le Morne-Rouge"
     ],
+    "name:ara_x_preferred":[
+        "\u0644\u0648\u0645\u0648\u0631\u0646 \u0631\u0648\u062c"
+    ],
     "name:arg_x_preferred":[
         "Le Morne-Rouge"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:ces_x_preferred":[
         "Le Morne-Rouge"
+    ],
+    "name:che_x_preferred":[
+        "\u041c\u043e\u0433\u04c0\u043d-\u0413\u04c0\u0443\u0436"
     ],
     "name:cos_x_preferred":[
         "Le Morne-Rouge"
@@ -160,6 +166,9 @@
     "name:lit_x_preferred":[
         "Le Morne-Rouge"
     ],
+    "name:lld_x_preferred":[
+        "Le Morne-Rouge"
+    ],
     "name:ltz_x_preferred":[
         "Le Morne-Rouge"
     ],
@@ -220,6 +229,9 @@
     "name:ron_x_preferred":[
         "Le Morne-Rouge"
     ],
+    "name:rus_x_preferred":[
+        "\u041b\u0435 \u041c\u043e\u0440\u043d-\u0420\u0443\u0436"
+    ],
     "name:scn_x_preferred":[
         "Le Morne-Rouge"
     ],
@@ -274,6 +286,9 @@
     "name:wol_x_preferred":[
         "Le Morne-Rouge"
     ],
+    "name:zho_x_preferred":[
+        "\u52d2\u83ab\u8bb7\u9c81\u65e5"
+    ],
     "name:zul_x_preferred":[
         "Le Morne-Rouge"
     ],
@@ -316,7 +331,7 @@
         }
     ],
     "wof:id":1125939107,
-    "wof:lastmodified":1566611881,
+    "wof:lastmodified":1690939776,
     "wof:name":"Le Morne-Rouge",
     "wof:parent_id":85671191,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.